### PR TITLE
Fixes to the build process for doom_py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ ViZDoom source code.
 * SDL 2.0.2
 * Python with Numpy
 
+To install dependencies on OS X via Brew, type
+
+```brew install cmake boost boost-python```
+
 To install dependencies on Ubuntu, type
 
 ```apt-get install -y python-numpy cmake zlib1g-dev libjpeg-dev libboost-all-dev gcc libsdl2-dev wget unzip```

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import sys
 import subprocess
 
 from distutils import sysconfig
-from distutils.command.build import build as DistutilsBuild
-from setuptools import setup, Extension
+from distutils.command.build_ext import build_ext as DistutilsBuild
+from setuptools import setup
 
 def build_common(dynamic_library_extension):
     python_include = sysconfig.get_python_inc()
@@ -68,7 +68,7 @@ setup(name='doom-py',
       author='OpenAI Community',
       author_email='gym@openai.com',
       packages=['doom_py'],
-      cmdclass={'build': BuildDoom},
+      cmdclass={'build_ext': BuildDoom},
       setup_requires=['numpy'],
       install_requires=['numpy'],
       tests_require=['nose2'],

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ def build_common(dynamic_library_extension):
     subprocess.check_call(['make', '-j', str(cores_to_use)], cwd='doom_py')
     subprocess.check_call(['rm', '-f', 'vizdoom.so'], cwd='doom_py')
     subprocess.check_call(['ln', '-s', 'bin/python/vizdoom.so', 'vizdoom.so'], cwd='doom_py')
+    print "all done with so, check: ", python_include, python_library
 
 def build_osx():
     build_common('dylib')
@@ -49,7 +50,14 @@ class BuildDoom(DistutilsBuild):
         try:
             build_func()
         except subprocess.CalledProcessError as e:
-            print("Could not build doom-py: %s" % e)
+            if platname == 'osx':
+                library_str = "doom_py requires boost and boost-python on OSX (installable via 'brew install boost boost-python')"
+            elif platname == 'linux':
+                library_str = "Try running 'apt-get install -y python-numpy cmake zlib1g-dev libjpeg-dev libboost-all-dev gcc libsdl2-dev wget unzip'"
+            else:
+                library_str = ''
+
+            sys.stderr.write("\033[1m" + "\nCould not build doom-py: %s. (HINT: are you sure cmake is installed? You might also be missing a library. %s\n\n" % (e, library_str) + "\033[0m")
             raise
         DistutilsBuild.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ def build_common(dynamic_library_extension):
     subprocess.check_call(['make', '-j', str(cores_to_use)], cwd='doom_py')
     subprocess.check_call(['rm', '-f', 'vizdoom.so'], cwd='doom_py')
     subprocess.check_call(['ln', '-s', 'bin/python/vizdoom.so', 'vizdoom.so'], cwd='doom_py')
-    print "all done with so, check: ", python_include, python_library
 
 def build_osx():
     build_common('dylib')


### PR DESCRIPTION
I added a message to the build process and README about possible missing packages on OSX (boost)

Also, 'setup.py develop' wasn't triggering CMake correctly because under setuptools the 'develop' step doesn't look for a 'build' step (unlike distutils). Overriding the 'build_ext' step instead. 
