### PR TITLE
Use SDL instead of Cocoa backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ViZDoom source code.
 
 To install dependencies on OS X via Brew, type
 
-```brew install cmake boost boost-python```
+```brew install cmake boost boost-python sdl2```
 
 To install dependencies on Ubuntu, type
 


### PR DESCRIPTION
VIzdoom's cocoa backend support on mac isn't complete (doesn't support window hiding). The SDL2 backend is more feature complete (and is used on linux and likely to be supported)
